### PR TITLE
feat: Add RSA KeyStore attestation support

### DIFF
--- a/app/src/main/aidl/io/github/vvb2060/keyattestation/keystore/IAndroidKeyStore.aidl
+++ b/app/src/main/aidl/io/github/vvb2060/keyattestation/keystore/IAndroidKeyStore.aidl
@@ -2,6 +2,7 @@ package io.github.vvb2060.keyattestation.keystore;
 
 import android.hardware.security.keymint.DeviceInfo;
 import android.hardware.security.keymint.RpcHardwareInfo;
+import io.github.vvb2060.keyattestation.keystore.KeyStoreKeyType;
 
 interface IAndroidKeyStore {
     byte[] getCertificateChain(String alias);
@@ -10,7 +11,7 @@ interface IAndroidKeyStore {
     void importKeyBox(String alias, boolean useStrongBox, in ParcelFileDescriptor pfd);
     byte[] generateKeyPair(String alias, String attestKeyAlias, boolean useStrongBox,
                            boolean includeProps, boolean uniqueIdIncluded, int idFlags,
-                           boolean useSak);
+                           KeyStoreKeyType keyStoreKeyType, boolean useSak);
     byte[] attestDeviceIds(int idFlags);
     void setRkpHostname(String hostname);
     String getRkpHostname();

--- a/app/src/main/aidl/io/github/vvb2060/keyattestation/keystore/KeyStoreKeyType.aidl
+++ b/app/src/main/aidl/io/github/vvb2060/keyattestation/keystore/KeyStoreKeyType.aidl
@@ -1,0 +1,7 @@
+// KeyStoreKeyType.aidl
+package io.github.vvb2060.keyattestation.keystore;
+
+enum KeyStoreKeyType {
+    ECDSA,
+    RSA
+}

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeFragment.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeFragment.kt
@@ -168,6 +168,7 @@ class HomeFragment : AppFragment(), HomeAdapter.Listener, MenuProvider {
         menu.findItem(R.id.menu_id_type_meid).isChecked = viewModel.preferIdAttestationMEID
         menu.findItem(R.id.menu_include_unique_id).isChecked = viewModel.preferIncludeUniqueId
         menu.findItem(R.id.menu_use_sak).isChecked = viewModel.preferSak
+        menu.findItem(R.id.menu_attest_rsa_key).isChecked = viewModel.preferAttestRsaKey
         if (!viewModel.hasSak) {
             menu.removeItem(R.id.menu_use_sak)
         }
@@ -215,6 +216,10 @@ class HomeFragment : AppFragment(), HomeAdapter.Listener, MenuProvider {
                 viewModel.preferAttestKey = status
                 viewModel.load()
             }
+            R.id.menu_attest_rsa_key -> {
+                viewModel.preferAttestRsaKey = status
+                viewModel.load()
+            }
             R.id.menu_include_props -> {
                 viewModel.preferIncludeProps = status
                 viewModel.load()
@@ -242,7 +247,7 @@ class HomeFragment : AppFragment(), HomeAdapter.Listener, MenuProvider {
                 viewModel.load(true)
             }
             R.id.menu_save -> {
-                save.launch("${Build.PRODUCT}-${AppApplication.TAG}.p7b")
+                save.launch("${Build.PRODUCT}-${AppApplication.TAG}-${if (viewModel.preferAttestRsaKey) "RSA" else "ECDSA"}.p7b")
             }
             R.id.menu_load -> {
                 load.launch("*/*")

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -36,6 +36,12 @@
         android:showAsAction="never"
         android:title="@string/attest_device_props" />
 
+    <item
+        android:id="@+id/menu_attest_rsa_key"
+        android:checkable="true"
+        android:showAsAction="never"
+        android:title="@string/attest_rsa_key" />
+
     <group android:id="@+id/menu_id_type_group">
         <item
             android:id="@+id/menu_id_type_serial"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,4 +353,5 @@
     <string name="knox_record_hash_description"><![CDATA[
     a SHA256 digest of the TA requesting the integrity status data from ICCC.
     ]]></string>
+    <string name="attest_rsa_key">Attest RSA key</string>
 </resources>

--- a/stub/src/main/java/android/security/keystore/KeyGenParameterSpec_rename.java
+++ b/stub/src/main/java/android/security/keystore/KeyGenParameterSpec_rename.java
@@ -60,6 +60,8 @@ public class KeyGenParameterSpec_rename {
             return this;
         }
 
+        public Builder setSignaturePaddings(String... paddings) { return this; }
+
         public KeyGenParameterSpec_rename build() {
             throw new RuntimeException("Stub!");
         }


### PR DESCRIPTION
Currently, the application only allowed verifying ECDSA keys as it lacked support for attesting RSA keys within the Android KeyStore. This PR adds support to perform a complete validation of the two currently supported asymmetric key types in the Android KeyStore. 

A new menu option "Attest RSA key" was added for this purpose. Additionally, when exporting the keychain in p7b format, the keystore's type will be included as part of the filename to differentiate between the ECDSA (current default) and RSA.

Prebuilt CI outputs:
* Build on [macOS-latest](https://github.com/user-attachments/files/21051788/macOS-latest-artifact.zip) (sha256:4afa6a44cd3380fc1c57e4b94d7e8eec3d56d41dc2b8363d087e39a28f907d99)
* Build on [ubuntu-latest](https://github.com/user-attachments/files/21051787/ubuntu-latest-artifact.zip) (sha256:de6c89b55a6390fba4ee40459e2492759cf5c4351640c52d3a16c26905a45af7)
* Build on [windows-latest](https://github.com/user-attachments/files/21051784/windows-latest-artifact.zip) (sha256:4130e6646f1a9d38f9b12d196aaec81c645abb27aa0264f084aac49ff38c9bee)
* [Link](https://github.com/linuxct/KeyAttestation/actions/runs/16061769180) to the CI run (for artifact attestation purposes)